### PR TITLE
Bump TF module and policy versions

### DIFF
--- a/manifests/terraform_modules/manifest/manifest.xml
+++ b/manifests/terraform_modules/manifest/manifest.xml
@@ -4,12 +4,12 @@
     all TF modules
 -->
 <manifest>
-  <project name="lcaf-component-tf-module" path="components/module" remote="launch-dso-platform" revision="refs/tags/0.1.0" dso_override_attribute_revision='${TERRAFORM_VER}'>
+  <project name="lcaf-component-tf-module" path="components/module" remote="launch-dso-platform" revision="refs/tags/0.3.0" dso_override_attribute_revision='${TERRAFORM_VER}'>
     <linkfile src="linkfiles/Makefile" dest="components/Makefile" />
     <linkfile src="linkfiles/.tflint.hcl" dest=".tflint.hcl" />
     <linkfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />
     <linkfile src="linkfiles/.golangci.yaml" dest=".golangci.yaml" />
   </project>
-  <project name="lcaf-component-policy" path="components/policy" remote="launch-dso-platform" revision="refs/tags/0.1.0" dso_override_attribute_revision='${POLICY_VER}'>
+  <project name="lcaf-component-policy" path="components/policy" remote="launch-dso-platform" revision="refs/tags/0.2.0" dso_override_attribute_revision='${POLICY_VER}'>
   </project>
 </manifest>


### PR DESCRIPTION
Changes TF modules to use the latest TF module component and policy component. This resolves several long-standing issues with `make check` not working and policy not being enforced.

Will move tag `0.2.0` to the merge commit from this PR to ensure all repos that are being automatically fixed by the script will be able to consume these changes (required, as `make check` is a stage in the fix script to validate the automated fixes).