### PR TITLE
Fix/bump tf module version

### DIFF
--- a/manifests/terraform_modules/manifest/manifest.xml
+++ b/manifests/terraform_modules/manifest/manifest.xml
@@ -4,7 +4,7 @@
     all TF modules
 -->
 <manifest>
-  <project name="lcaf-component-tf-module" path="components/module" remote="launch-dso-platform" revision="refs/tags/0.3.0" dso_override_attribute_revision='${TERRAFORM_VER}'>
+  <project name="lcaf-component-tf-module" path="components/module" remote="launch-dso-platform" revision="refs/tags/0.3.1" dso_override_attribute_revision='${TERRAFORM_VER}'>
     <linkfile src="linkfiles/Makefile" dest="components/Makefile" />
     <linkfile src="linkfiles/.tflint.hcl" dest=".tflint.hcl" />
     <linkfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />

--- a/manifests/terraform_modules/manifest/manifest.xml
+++ b/manifests/terraform_modules/manifest/manifest.xml
@@ -4,12 +4,12 @@
     all TF modules
 -->
 <manifest>
-  <project name="lcaf-component-tf-module" path="components/module" remote="launch-dso-platform" revision="refs/tags/0.3.1" dso_override_attribute_revision='${TERRAFORM_VER}'>
+  <project name="lcaf-component-tf-module" path="components/module" remote="launch-dso-platform" revision="refs/tags/0.3.2" dso_override_attribute_revision='${TERRAFORM_VER}'>
     <linkfile src="linkfiles/Makefile" dest="components/Makefile" />
     <linkfile src="linkfiles/.tflint.hcl" dest=".tflint.hcl" />
     <linkfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />
     <linkfile src="linkfiles/.golangci.yaml" dest=".golangci.yaml" />
   </project>
-  <project name="lcaf-component-policy" path="components/policy" remote="launch-dso-platform" revision="refs/tags/0.2.0" dso_override_attribute_revision='${POLICY_VER}'>
+  <project name="lcaf-component-policy" path="components/policy" remote="launch-dso-platform" revision="refs/tags/0.2.1" dso_override_attribute_revision='${POLICY_VER}'>
   </project>
 </manifest>

--- a/manifests/terragrunt/manifest/manifest.xml
+++ b/manifests/terragrunt/manifest/manifest.xml
@@ -8,6 +8,6 @@
    <project name="lcaf-component-tf-module" path="components/module" remote="launch-dso-platform" revision="refs/tags/0.2.0" dso_override_attribute_revision='${TERRAFORM_VER}'>
     <linkfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />
   </project>
-  <project name="lcaf-component-policy" path="components/policy" remote="launch-dso-platform" revision="refs/tags/0.1.0" dso_override_attribute_revision='${POLICY_VER}'>
+  <project name="lcaf-component-policy" path="components/policy" remote="launch-dso-platform" revision="refs/tags/0.2.1" dso_override_attribute_revision='${POLICY_VER}'>
   </project>
 </manifest>


### PR DESCRIPTION
Upon merge, this will be released as tagged version `0.2.1.`

Incorporates the following fixes:

* Autogenerated AWS provider now respects environment variables (https://github.com/nexient-llc/lcaf-component-tf-module/pull/11)
* Ensures dirty components are rectified before additional pre-commit actions are taken (https://github.com/nexient-llc/lcaf-component-tf-module/pull/12)
* Adds policy allowing `aztfmod/azurecaf` provider to be used with the platform (https://github.com/nexient-llc/lcaf-component-policy/pull/5)
* Completes migration of all Rego files to the policy component (https://github.com/nexient-llc/lcaf-component-tf-module/pull/13 and https://github.com/nexient-llc/lcaf-component-policy/pull/6)
* Autogenerated Azure provider no longer creates an empty file (https://github.com/nexient-llc/lcaf-component-tf-module/pull/13)