### PR TITLE
Feature/split make check

### DIFF
--- a/manifests/containers/aws/build_agents/shared_service/terraform/manifest/manifest.xml
+++ b/manifests/containers/aws/build_agents/shared_service/terraform/manifest/manifest.xml
@@ -3,7 +3,7 @@
     This manifest defines the behavior of container components
 -->
 <manifest>
-  <project name="lcaf-component-container" path="components/container" remote="launch-dso-platform" revision="refs/tags/0.1.0" dso_override_attribute_revision='${CONTAINER_VER}'>
+  <project name="lcaf-component-container" path="components/container" remote="launch-dso-platform" revision="refs/tags/0.2.0" dso_override_attribute_revision='${CONTAINER_VER}'>
     <linkfile src="linkfiles/Makefile.container.includes" dest="Makefile.container.includes" />
   </project>
   <project name="lcaf-component-aws-pipeline" path="components/module" remote="launch-dso-platform" revision="refs/tags/0.1.0" dso_override_attribute_revision='${PIPELINES_VER}'>

--- a/manifests/containers/generic/manifest/manifest.xml
+++ b/manifests/containers/generic/manifest/manifest.xml
@@ -3,7 +3,7 @@
     This manifest defines the behavior of generic containerized components
 -->
 <manifest>
-  <project name="lcaf-component-container" path="components/container" remote="launch-dso-platform" revision="refs/tags/0.1.0" dso_override_attribute_revision='${CONTAINER_VER}'>
+  <project name="lcaf-component-container" path="components/container" remote="launch-dso-platform" revision="refs/tags/0.2.0" dso_override_attribute_revision='${CONTAINER_VER}'>
     <linkfile src="linkfiles/Makefile.container.includes" dest="Makefile.container.includes" />
   </project>
   <project name="git-webhook-lambda" path="components/git-webhook-lambda" remote="launch-dso-platform" revision="refs/tags/0.1.0" dso_override_attribute_revision='${WEBHOOK_VER}'>

--- a/manifests/containers/java/wildfly/manifest/manifest.xml
+++ b/manifests/containers/java/wildfly/manifest/manifest.xml
@@ -3,7 +3,7 @@
     This manifest defines the behavior of container components
 -->
 <manifest>
-  <project name="lcaf-component-container" path="components/module" remote="launch-dso-platform" revision="refs/tags/0.1.0" dso_override_attribute_revision='${CONTAINER_VER}'>
+  <project name="lcaf-component-container" path="components/module" remote="launch-dso-platform" revision="refs/tags/0.2.0" dso_override_attribute_revision='${CONTAINER_VER}'>
     <linkfile src="linkfiles/Makefile" dest="components/Makefile" />
     <linkfile src="linkfiles/Makefile.container.includes" dest="Makefile.container.includes" />
     <linkfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />

--- a/manifests/containers/python/manifest/manifest.xml
+++ b/manifests/containers/python/manifest/manifest.xml
@@ -3,7 +3,7 @@
     This manifest defines the behavior of containerized Python components
 -->
 <manifest>
-  <project name="lcaf-component-container" path="components/container" remote="launch-dso-platform" revision="refs/tags/0.1.0" dso_override_attribute_revision='${CONTAINER_VER}'>
+  <project name="lcaf-component-container" path="components/container" remote="launch-dso-platform" revision="refs/tags/0.2.0" dso_override_attribute_revision='${CONTAINER_VER}'>
     <linkfile src="linkfiles/Makefile.container.includes" dest="Makefile.container.includes" />
   </project>
   <project name="lcaf-component-python" path="components/python" remote="launch-dso-platform" revision="refs/tags/0.1.0" dso_override_attribute_revision='${PYTHON_VER}'>

--- a/manifests/platform/manifest/manifest.xml
+++ b/manifests/platform/manifest/manifest.xml
@@ -4,7 +4,7 @@
     anything in the Launch Platform space.
 -->
 <manifest>
-  <project name="lcaf-component-platform" path="components/platform" remote="launch-dso-platform" revision="refs/tags/0.1.0" dso_override_attribute_revision='${PLATFORM_VER}'>
+  <project name="lcaf-component-platform" path="components/platform" remote="launch-dso-platform" revision="refs/tags/0.2.0" dso_override_attribute_revision='${PLATFORM_VER}'>
     <linkfile src="linkfiles/Makefile" dest="components/Makefile" />
   </project>
 </manifest>

--- a/manifests/terraform_modules/manifest/manifest.xml
+++ b/manifests/terraform_modules/manifest/manifest.xml
@@ -4,7 +4,7 @@
     all TF modules
 -->
 <manifest>
-  <project name="lcaf-component-tf-module" path="components/module" remote="launch-dso-platform" revision="refs/tags/0.3.2" dso_override_attribute_revision='${TERRAFORM_VER}'>
+  <project name="lcaf-component-tf-module" path="components/module" remote="launch-dso-platform" revision="refs/tags/0.4.0" dso_override_attribute_revision='${TERRAFORM_VER}'>
     <linkfile src="linkfiles/Makefile" dest="components/Makefile" />
     <linkfile src="linkfiles/.tflint.hcl" dest=".tflint.hcl" />
     <linkfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />

--- a/manifests/terragrunt/manifest/manifest.xml
+++ b/manifests/terragrunt/manifest/manifest.xml
@@ -3,9 +3,7 @@
     This manifest defines the behavior of aws terragrunt components
 -->
 <manifest>
-  <project name="lcaf-component-terragrunt" path="components/terragrunt" remote="launch-dso-platform" revision="refs/tags/0.2.2" dso_override_attribute_revision='${TERRAGRUNT_VER}'>
-  </project>
-   <project name="lcaf-component-tf-module" path="components/module" remote="launch-dso-platform" revision="refs/tags/0.2.0" dso_override_attribute_revision='${TERRAFORM_VER}'>
+  <project name="lcaf-component-terragrunt" path="components/terragrunt" remote="launch-dso-platform" revision="refs/tags/0.3.0" dso_override_attribute_revision='${TERRAGRUNT_VER}'>
     <linkfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />
   </project>
   <project name="lcaf-component-policy" path="components/policy" remote="launch-dso-platform" revision="refs/tags/0.2.1" dso_override_attribute_revision='${POLICY_VER}'>


### PR DESCRIPTION
Splits `make check` into two subtargets: `make lint` and `make test`

Terragrunt manifest now pulls from its own component's `.pre-commit-config.yaml` instead of from the Terraform module.